### PR TITLE
Create libraries dir if needed, fix name in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ This repository contains uncompiled JavaScript for Automation code. You can open
 
 and run them in Script Editor (NB choose JavaScript in the language selector at top left), but they need a compiled version of “PashuaJS.applescript” (which is also in this folder) to be copied to ~/Library/Script Libraries/ as PashuaJS.scpt
 
-One solution: simply open a Terminal window, run “compile.sh” (i.e. cd to the folder containing these files, then drag the icon of `compile.sh` onto the Terminal window and hit Return) and you’re done. You should now have:
+One solution: simply open a Terminal window, run “compileJS.sh” (i.e. cd to the folder containing these files, then drag the icon of `compileJS.sh` onto the Terminal window and hit Return) and you’re done. You should now have:
 - “Example1ConfigTextJS.scpt”
 - “Example2ConfigObjectJS.scpt”
 - “Example3MixedJS.applescript”

--- a/compileJS.sh
+++ b/compileJS.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ ! -e "$HOME/Library/Script Libraries" ]
+then
+	mkdir "$HOME/Library/Script Libraries"
+fi
+
+if [ ! -d "$HOME/Library/Script Libraries" ]
+then
+	>&2 echo "Not a directory: $HOME/Library/Script Libraries"
+	exit 1
+fi
+
 osacompile -l JavaScript -o "$HOME/Library/Script Libraries/PashuaJS.scpt"  "$DIR/PashuaJS.applescript"
 osacompile -l JavaScript -o "Example1ConfigTextJS.scpt" "$DIR/Example1ConfigTextJS.applescript"
 osacompile -l JavaScript -o "Example2ConfigObjectJS.scpt" "$DIR/Example2ConfigObjectJS.applescript"


### PR DESCRIPTION
`compileJS.sh` didn’t check whether `$HOME/Library/Script Libraries` exists – so I got an error upon first run.

Second, the script’s filename in the Readme was “scripts.sh”
